### PR TITLE
ci: tokio rt feature flag needed for spawn

### DIFF
--- a/netbench/Cargo.toml
+++ b/netbench/Cargo.toml
@@ -25,7 +25,7 @@ s2n-quic-core = { version = "*", features = ["testing"] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 sha2 = "0.10"
-tokio = { version = "1", features = ["net", "time"] }
+tokio = { version = "1", features = ["net", "rt", "time"] }
 
 [dev-dependencies]
 futures-test = "0.3"


### PR DESCRIPTION
### Resolved issues:

none

### Description of changes: 

Discovered while trying todo `cargo publish`

### Call-outs:

```
cargo package
...
   Compiling s2n-netbench v0.1.0 (/Users/dougch/gitrepos/s2n-netbench/target/package/s2n-netbench-0.1.0)
error[E0425]: cannot find function `spawn` in crate `tokio`
   --> src/trace.rs:567:16
    |
567 |         tokio::spawn(async move {
    |                ^^^^^ not found in `tokio`
    |
note: found an item that was configured out
   --> /Users/dougch/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.35.0/src/lib.rs:546:19
    |
546 |     pub use task::spawn;
    |                   ^^^^^
    = note: the item is gated behind the `rt` feature
help: consider importing this function
    |
4   + use std::thread::spawn;
    |
help: if you import `spawn`, refer to it directly
    |
567 -         tokio::spawn(async move {
567 +         spawn(async move {
    |

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

