### PR TITLE
chore: Missing metadata needed for crates.io publish.

### DIFF
--- a/netbench-cli/Cargo.toml
+++ b/netbench-cli/Cargo.toml
@@ -2,6 +2,8 @@
 name = "s2n-netbench-cli"
 version = "0.1.0"
 authors = ["AWS s2n"]
+description = "Internal crate used by s2n-netbench"
+repository = "https://github.com/aws/s2n-netbench"
 edition = "2021"
 rust-version = "1.74"
 license = "Apache-2.0"

--- a/netbench-collector/Cargo.toml
+++ b/netbench-collector/Cargo.toml
@@ -2,6 +2,8 @@
 name = "s2n-netbench-collector"
 version = "0.1.0"
 authors = ["AWS s2n"]
+description = "Internal crate used by s2n-netbench"
+repository = "https://github.com/aws/s2n-netbench"
 edition = "2021"
 rust-version = "1.74"
 license = "Apache-2.0"

--- a/netbench-scenarios/Cargo.toml
+++ b/netbench-scenarios/Cargo.toml
@@ -2,6 +2,8 @@
 name = "s2n-netbench-scenarios"
 version = "0.1.0"
 authors = ["AWS s2n"]
+description = "Internal crate used by s2n-netbench"
+repository = "https://github.com/aws/s2n-netbench"
 edition = "2021"
 rust-version = "1.74"
 license = "Apache-2.0"

--- a/netbench/Cargo.toml
+++ b/netbench/Cargo.toml
@@ -2,6 +2,8 @@
 name = "s2n-netbench"
 # this in an unpublished internal crate so the version should not be changed
 version = "0.1.0"
+description = "An efficiency, performance, and correctness analysis tool for transport protocols."
+repository = "https://github.com/aws/s2n-netbench"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.74"


### PR DESCRIPTION
### Resolved issues:

n/a

### Description of changes: 

Crates.io has a list of [required fields](https://doc.rust-lang.org/cargo/reference/publishing.html), adding in some of these.

### Call-outs:

The list appears in-accurate/out of date and `cargo publish --dry-run` does not check for required fields.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

