### PR TITLE
chore: wildcard deps not allowed on crates.io

### DIFF
--- a/netbench/Cargo.toml
+++ b/netbench/Cargo.toml
@@ -23,7 +23,7 @@ once_cell = "1"
 openssl = "0.10.46"
 probe = "0.5"
 rcgen = "0.11"
-s2n-quic-core = { version = "*", features = ["testing"] }
+s2n-quic-core = { version = "0.32.0", features = ["testing"] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 sha2 = "0.10"


### PR DESCRIPTION
### Resolved issues:

n/a

### Description of changes: 

Publish now failing with 

```
error: failed to publish to registry at https://crates.io

Caused by:
  the remote server responded with an error: wildcard (`*`) dependency constraints are not allowed on crates.io. Crate with this problem: `s2n-quic-core` See https://doc.rust-lang.org/cargo/faq.html#can-libraries-use--as-a-version-for-their-dependencies for more information
```

### Call-outs:

We're clearly missing some CI checks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

