### PR TITLE
chore: publish drivers

### DIFF
--- a/netbench-driver-native-tls/Cargo.toml
+++ b/netbench-driver-native-tls/Cargo.toml
@@ -2,6 +2,8 @@
 name = "s2n-netbench-driver-native-tls"
 version = "0.1.0"
 authors = ["AWS s2n"]
+description = "s2n-netbench driver for native tls"
+repository = "https://github.com/aws/s2n-netbench"
 edition = "2021"
 rust-version = "1.74"
 license = "Apache-2.0"

--- a/netbench-driver-s2n-quic/Cargo.toml
+++ b/netbench-driver-s2n-quic/Cargo.toml
@@ -2,6 +2,8 @@
 name = "s2n-netbench-driver-s2n-quic"
 version = "0.1.0"
 authors = ["AWS s2n"]
+description = "s2n-netbench driver for s2n-quic"
+repository = "https://github.com/aws/s2n-netbench"
 edition = "2021"
 rust-version = "1.74"
 license = "Apache-2.0"

--- a/netbench-driver-s2n-tls/Cargo.toml
+++ b/netbench-driver-s2n-tls/Cargo.toml
@@ -2,6 +2,8 @@
 name = "s2n-netbench-driver-s2n-tls"
 version = "0.1.0"
 authors = ["AWS s2n"]
+description = "s2n-netbench driver for s2n-tls"
+repository = "https://github.com/aws/s2n-netbench"
 edition = "2021"
 rust-version = "1.74"
 license = "Apache-2.0"

--- a/netbench-driver-tcp/Cargo.toml
+++ b/netbench-driver-tcp/Cargo.toml
@@ -2,6 +2,8 @@
 name = "s2n-netbench-driver-tcp"
 version = "0.1.0"
 authors = ["AWS s2n"]
+description = "s2n-netbench driver for tcp"
+repository = "https://github.com/aws/s2n-netbench"
 edition = "2021"
 rust-version = "1.74"
 license = "Apache-2.0"

--- a/netbench-driver/Cargo.toml
+++ b/netbench-driver/Cargo.toml
@@ -2,6 +2,8 @@
 name = "s2n-netbench-driver"
 version = "0.1.0"
 authors = ["AWS s2n"]
+description = "Internal crate used by s2n-netbench"
+repository = "https://github.com/aws/s2n-netbench"
 edition = "2021"
 rust-version = "1.74"
 license = "Apache-2.0"


### PR DESCRIPTION
### Description of changes: 
Publishes netbench drivers.

### Call-outs:
We as a team discussed that eventually the drivers (s2n-quic, s2n-tls) should live in their respective project repository. That is something we can still do in the future. I would like to publish the drivers now so that its possible to use them for the Netbench Orchestrator project.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

