### PR TITLE
s2n-netbench-scenario: move legend to the bottom

### DIFF
--- a/netbench-cli/src/report.rs
+++ b/netbench-cli/src/report.rs
@@ -59,6 +59,7 @@ impl Report {
                 .last()
                 .unwrap()
                 .trim_start_matches("netbench-driver-")
+                .trim_start_matches("s2n-netbench-driver-")
                 .to_string();
 
             let scenario_name = scenario

--- a/netbench-cli/src/vega.json
+++ b/netbench-cli/src/vega.json
@@ -16,7 +16,7 @@
     },
     "legend": {
       "labelBaseline": "middle",
-      "labelFontSize": 9,
+      "labelFontSize": 11,
       "symbolSize": 50,
       "symbolType": "square",
       "orient": "bottom"

--- a/netbench-cli/src/vega.json
+++ b/netbench-cli/src/vega.json
@@ -16,9 +16,10 @@
     },
     "legend": {
       "labelBaseline": "middle",
-      "labelFontSize": 11,
+      "labelFontSize": 9,
       "symbolSize": 50,
-      "symbolType": "square"
+      "symbolType": "square",
+      "orient": "bottom"
     }
   },
 


### PR DESCRIPTION
### Description of changes: 
Since driver names can be quite long, the legend can get cut off. This PR changes the location of the legend to the bottom (which avoids side scrolling and is easier to see).

I also thought of reducing the font size but that seemed a bit arbitrary and prob should be fixed by being able to provide a shorter driver name.

### Testing:
[sample report](https://d37mm99fcr6hy4.cloudfront.net/1616ca0c7878ef81b52a86bc44e3c8e8731f59bd/netbench/index.html#request_response/clients.json)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

