### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
             --request_response.response_size=8GiB
 
           SCENARIOS=$(find target/s2n-netbench -type f -exec basename -s .json {} \; | jq -Rcs 'rtrimstr("\n") | split("\n")')
-          echo "::set-output name=scenarios::$SCENARIOS"
+          echo "scenarios=$SCENARIOS" >> $GITHUB_OUTPUT
 
       - name: Prepare artifact
         run: |
@@ -315,7 +315,7 @@ jobs:
           TARGET="${{ github.sha }}/netbench"
           aws s3 sync reports "s3://netbenchrunnerlogs-prod/$TARGET" --acl private --follow-symlinks
           URL="$CDN/$TARGET/index.html"
-          echo "::set-output name=URL::$URL"
+          echo "URL=$URL" >> $GITHUB_OUTPUT
 
       - uses: ouzi-dev/commit-status-updater@v2.0.1
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter