### PR TITLE
feat(netbench): add builder feature to avoid openssl dependency in drivers

### DIFF
--- a/netbench-scenarios/Cargo.toml
+++ b/netbench-scenarios/Cargo.toml
@@ -11,4 +11,4 @@ license = "Apache-2.0"
 [dependencies]
 clap = { version = "2", features = ["color", "suggestions"] }
 humantime = "2"
-netbench = { version = "0.1", path = "../netbench", package = "s2n-netbench" }
+netbench = { version = "0.1", path = "../netbench", package = "s2n-netbench", features = ["builder"] }

--- a/netbench/Cargo.toml
+++ b/netbench/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 rust-version = "1.74"
 license = "Apache-2.0"
 
+[features]
+builder = ["dep:openssl", "dep:rcgen"]
+
 [dependencies]
 base64 = "0.13"
 bytes = "1"
@@ -20,9 +23,9 @@ num-traits = "0.2"
 once_cell = "1"
 # openssl deprecated the old pkcs builder and added a new preferred function
 # inside of patch versions, so we explicitly require at least patch
-openssl = "0.10.46"
+openssl = { version = "0.10.46", optional = true }
 probe = "0.5"
-rcgen = "0.11"
+rcgen = { version = "0.11", optional = true }
 s2n-quic-core = { version = "0.32.0", features = ["testing"] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"

--- a/netbench/src/operation.rs
+++ b/netbench/src/operation.rs
@@ -72,6 +72,8 @@ pub enum IterateValue {
     Count { amount: u64 },
 }
 
+// builder helpers
+#[cfg(feature = "builder")]
 impl IterateValue {
     pub(crate) fn is_zero(&self) -> bool {
         match self {

--- a/netbench/src/scenario.rs
+++ b/netbench/src/scenario.rs
@@ -5,9 +5,11 @@ use crate::{operation as op, Result};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, path::Path, sync::Arc};
 
+#[cfg(feature = "builder")]
 pub mod builder;
 mod id;
 
+#[cfg(feature = "builder")]
 pub use builder::Builder;
 pub use id::Id;
 
@@ -25,6 +27,7 @@ pub struct Scenario {
 }
 
 impl Scenario {
+    #[cfg(feature = "builder")]
     pub fn build<F: FnOnce(&mut builder::Builder)>(f: F) -> Self {
         let mut builder = builder::Builder::new();
         f(&mut builder);

--- a/netbench/src/scenario/id.rs
+++ b/netbench/src/scenario/id.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 pub struct Id(String);
 
 impl Id {
-    pub(crate) fn hasher() -> Hasher {
+    pub fn hasher() -> Hasher {
         Hasher::default()
     }
 }


### PR DESCRIPTION
### Description of changes: 

The `netbench` crate currently pulls in `openssl` to generate pkcs12-encoded certificates for scenarios. This means that anything that depends on the `netbench` crate will pull in the `openssl` dependency, even if it's not needing this functionality.

Instead, we put the scenario builder implementation behind a feature flag so the majority of dependents can avoid pulling openssl.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

