### PR TITLE
feat: add support for file logger

### DIFF
--- a/netbench-driver-native-tls/src/bin/client.rs
+++ b/netbench-driver-native-tls/src/bin/client.rs
@@ -18,18 +18,18 @@ use tokio_native_tls::{
 static ALLOCATOR: Allocator = Allocator::new();
 
 fn main() -> Result<()> {
-    let args = Client::parse();
+    let args = NetbenchClient::parse();
     let runtime = args.opts.runtime();
     runtime.block_on(args.run())
 }
 
 #[derive(Debug, Parser)]
-pub struct Client {
+pub struct NetbenchClient {
     #[command(flatten)]
     opts: netbench_driver::Client,
 }
 
-impl Client {
+impl NetbenchClient {
     pub async fn run(&self) -> Result<()> {
         let addresses = self.opts.address_map().await?;
         let scenario = self.opts.scenario();

--- a/netbench-driver-native-tls/src/bin/server.rs
+++ b/netbench-driver-native-tls/src/bin/server.rs
@@ -16,18 +16,18 @@ use tokio_native_tls::native_tls::{Identity, TlsAcceptor};
 static ALLOCATOR: Allocator = Allocator::new();
 
 fn main() -> Result<()> {
-    let args = Server::parse();
+    let args = NetbenchServer::parse();
     let runtime = args.opts.runtime();
     runtime.block_on(args.run())
 }
 
 #[derive(Debug, Parser)]
-pub struct Server {
+pub struct NetbenchServer {
     #[command(flatten)]
     opts: netbench_driver::Server,
 }
 
-impl Server {
+impl NetbenchServer {
     pub async fn run(&self) -> Result<()> {
         let scenario = self.opts.scenario();
         let buffer = (*self.opts.rx_buffer as usize, *self.opts.tx_buffer as usize);

--- a/netbench-driver-s2n-quic/src/bin/client.rs
+++ b/netbench-driver-s2n-quic/src/bin/client.rs
@@ -11,13 +11,13 @@ use std::collections::HashSet;
 static ALLOCATOR: Allocator = Allocator::new();
 
 fn main() -> Result<()> {
-    let args = Client::parse();
+    let args = NetbenchClient::parse();
     let runtime = args.opts.runtime();
     runtime.block_on(args.run())
 }
 
 #[derive(Debug, Parser)]
-pub struct Client {
+pub struct NetbenchClient {
     #[command(flatten)]
     opts: netbench_driver::Client,
 
@@ -28,7 +28,7 @@ pub struct Client {
     disable_gso: bool,
 }
 
-impl Client {
+impl NetbenchClient {
     pub async fn run(&self) -> Result<()> {
         let addresses = self.opts.address_map().await?;
         let scenario = self.opts.scenario();

--- a/netbench-driver-s2n-quic/src/bin/server.rs
+++ b/netbench-driver-s2n-quic/src/bin/server.rs
@@ -12,13 +12,13 @@ use tokio::spawn;
 static ALLOCATOR: Allocator = Allocator::new();
 
 fn main() -> Result<()> {
-    let args = Server::parse();
+    let args = NetbenchServer::parse();
     let runtime = args.opts.runtime();
     runtime.block_on(args.run())
 }
 
 #[derive(Debug, Parser)]
-pub struct Server {
+pub struct NetbenchServer {
     #[command(flatten)]
     opts: netbench_driver::Server,
 
@@ -29,7 +29,7 @@ pub struct Server {
     disable_gso: bool,
 }
 
-impl Server {
+impl NetbenchServer {
     pub async fn run(&self) -> Result<()> {
         let scenario = self.opts.scenario();
         let trace = self.opts.trace();

--- a/netbench-driver-s2n-tls/src/bin/client.rs
+++ b/netbench-driver-s2n-tls/src/bin/client.rs
@@ -17,18 +17,18 @@ use tokio::net::TcpStream;
 static ALLOCATOR: Allocator = Allocator::new();
 
 fn main() -> Result<()> {
-    let args = Client::parse();
+    let args = NetbenchClient::parse();
     let runtime = args.opts.runtime();
     runtime.block_on(args.run())
 }
 
 #[derive(Debug, Parser)]
-pub struct Client {
+pub struct NetbenchClient {
     #[command(flatten)]
     opts: netbench_driver::Client,
 }
 
-impl Client {
+impl NetbenchClient {
     pub async fn run(&self) -> Result<()> {
         let addresses = self.opts.address_map().await?;
         let scenario = self.opts.scenario();

--- a/netbench-driver-s2n-tls/src/bin/server.rs
+++ b/netbench-driver-s2n-tls/src/bin/server.rs
@@ -20,18 +20,18 @@ use tokio::{
 static ALLOCATOR: Allocator = Allocator::new();
 
 fn main() -> Result<()> {
-    let args = Server::parse();
+    let args = NetbenchServer::parse();
     let runtime = args.opts.runtime();
     runtime.block_on(args.run())
 }
 
 #[derive(Debug, Parser)]
-pub struct Server {
+pub struct NetbenchServer {
     #[command(flatten)]
     opts: netbench_driver::Server,
 }
 
-impl Server {
+impl NetbenchServer {
     pub async fn run(&self) -> Result<()> {
         let scenario = self.opts.scenario();
 

--- a/netbench-driver-tcp/src/bin/client.rs
+++ b/netbench-driver-tcp/src/bin/client.rs
@@ -14,18 +14,18 @@ use tokio::{
 static ALLOCATOR: Allocator = Allocator::new();
 
 fn main() -> Result<()> {
-    let args = Client::parse();
+    let args = NetbenchClient::parse();
     let runtime = args.opts.runtime();
     runtime.block_on(args.run())
 }
 
 #[derive(Debug, Parser)]
-pub struct Client {
+pub struct NetbenchClient {
     #[command(flatten)]
     opts: netbench_driver::Client,
 }
 
-impl Client {
+impl NetbenchClient {
     pub async fn run(&self) -> Result<()> {
         let addresses = self.opts.address_map().await?;
         let scenario = self.opts.scenario();

--- a/netbench-driver-tcp/src/bin/server.rs
+++ b/netbench-driver-tcp/src/bin/server.rs
@@ -15,18 +15,18 @@ use tokio::{
 static ALLOCATOR: Allocator = Allocator::new();
 
 fn main() -> Result<()> {
-    let args = Server::parse();
+    let args = NetbenchServer::parse();
     let runtime = args.opts.runtime();
     runtime.block_on(args.run())
 }
 
 #[derive(Debug, Parser)]
-pub struct Server {
+pub struct NetbenchServer {
     #[command(flatten)]
     opts: netbench_driver::Server,
 }
 
-impl Server {
+impl NetbenchServer {
     pub async fn run(&self) -> Result<()> {
         let scenario = self.opts.scenario();
         let buffer = (*self.opts.rx_buffer as usize, *self.opts.tx_buffer as usize);

--- a/netbench/src/trace.rs
+++ b/netbench/src/trace.rs
@@ -421,8 +421,11 @@ impl Output for Arc<Mutex<std::io::BufWriter<std::fs::File>>> {
     ) -> std::io::Result<()> {
         let mut writer = self.lock().unwrap();
         f(&mut writer)?;
-        use std::io::Write;
-        writer.flush()?;
+
+        // Avoid flushing writes on each iteration since File I/O can get
+        // expensive. Instead rely on BufWriter to flush on Drop.
+        // https://doc.rust-lang.org/src/std/io/buffered/bufwriter.rs.html#673
+
         Ok(())
     }
 }

--- a/netbench/src/trace.rs
+++ b/netbench/src/trace.rs
@@ -397,15 +397,7 @@ impl FileLogger {
 
 impl Clone for FileLogger {
     fn clone(&self) -> Self {
-        let output = std::fs::File::try_clone(self.output.get_ref()).unwrap();
-        let output = std::io::BufWriter::new(output);
-        Self {
-            id: self.id,
-            traces: self.traces.clone(),
-            scope: vec![],
-            output,
-            verbose: self.verbose,
-        }
+        panic!("clone not supported for FileLogger")
     }
 }
 

--- a/netbench/src/trace.rs
+++ b/netbench/src/trace.rs
@@ -397,7 +397,15 @@ impl FileLogger {
 
 impl Clone for FileLogger {
     fn clone(&self) -> Self {
-        panic!("clone not supported for FileLogger")
+        let output = std::fs::File::try_clone(self.output.get_ref()).unwrap();
+        let output = std::io::BufWriter::new(output);
+        Self {
+            id: self.id,
+            traces: self.traces.clone(),
+            scope: vec![],
+            output,
+            verbose: self.verbose,
+        }
     }
 }
 


### PR DESCRIPTION
### Description of changes: 
Add the ability to log netbench traces to a file in addition to the existing stdout. This allows us to get netbench logs while using the collector, which tends to read from stdout.

### Callout:
A newer version of [clap](https://github.com/clap-rs/clap/discussions/4306) adds warning for same arg names so I prefixed Client/Server with Netbench. This is just a refactor change.

### Testing:
Ran locally and verified that the driver write to a log file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

