### PR TITLE
feat: Add additional values to CDK output

### DIFF
--- a/netbench-cdk/.gitignore
+++ b/netbench-cdk/.gitignore
@@ -10,6 +10,9 @@ cdk.out
 # After bootstrapping this has regions
 cdk.context.json
 
+# CDK output
+cdk_config.json
+
 ### CDK-specific ignores ###
 *.swp
 cdk.context.json

--- a/netbench-cdk/Makefile
+++ b/netbench-cdk/Makefile
@@ -18,7 +18,7 @@ endif
 
 deploy: build
 ifdef DEV_ACCOUNT_ID
-	cdk deploy NetbenchInfraDev-$(USER) --require-approval never
+	cdk deploy NetbenchInfraDev-$(USER) --require-approval never -O cdk_config.json
 endif
 
 state-backup:

--- a/netbench-cdk/lib/netbench.ts
+++ b/netbench-cdk/lib/netbench.ts
@@ -15,7 +15,6 @@ export class NetbenchInfra extends cdk.Stack {
 
     constructor(scope: Construct, id: string, props?: NetbenchStackProps) {
         super(scope, id, props);
-        this.createPlacementGroups();
         this.createVPC();
         this.createCloudwatchGroup();
         this.createRole();
@@ -51,26 +50,6 @@ export class NetbenchInfra extends cdk.Stack {
         new cdk.CfnOutput(this, "output:NetbenchRunnerLogGroup", { value: logGroup.logGroupName })
     }
 
-    private createPlacementGroups() {
-        const cluster = new ec2.PlacementGroup(this, 'Cluster', {
-            placementGroupName: 'NetbenchRunnerPlacementGroupCluster',
-            strategy: ec2.PlacementGroupStrategy.CLUSTER
-        });
-        new cdk.CfnOutput(this, "output:NetbenchRunnerPlacementGroupCluster", { value: cluster.placementGroupName })
-        // Max 7 partitions per AZ: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html
-        const partition = new ec2.PlacementGroup(this, 'Partition', {
-            placementGroupName: 'NetbenchRunnerPlacementGroupPartition',
-            partitions: 7,
-            strategy: ec2.PlacementGroupStrategy.PARTITION
-        });
-        new cdk.CfnOutput(this, "output:NetbenchRunnerPlacementGroupPartition", { value: partition.placementGroupName })
-        const spread = new ec2.PlacementGroup(this, 'Spread', {
-            placementGroupName: 'NetbenchRunnerPlacementGroupSpread',
-            spreadLevel: ec2.PlacementGroupSpreadLevel.RACK,
-            strategy: ec2.PlacementGroupStrategy.SPREAD
-        })
-        new cdk.CfnOutput(this, "output:NetbenchRunnerPlacementGroupSpread", { value: spread.placementGroupName })
-    }
     private createVPC() {
         // Creating VPC for clients and servers
         const vpc = new ec2.Vpc(this, 'vpc', {

--- a/netbench-cdk/lib/netbench.ts
+++ b/netbench-cdk/lib/netbench.ts
@@ -29,9 +29,11 @@ export class NetbenchInfra extends cdk.Stack {
                 throw new Error('Unable to determine reporting bucket suffix');
             }
             const distBucket = this.createS3Bucket(bucketName, true);
+            new cdk.CfnOutput(this, "output:NetbenchRunnerPublicLogsBucket", { value: distBucket.bucketName })
             this.createCloudFront('CFdistribution', distBucket);
             // Create the private source code bucket, without any distribution.
             const srcCodeBucket = this.createS3Bucket(`netbenchrunner-private-source-${props.bucketSuffix}`, false);
+            new cdk.CfnOutput(this, "output:NetbenchRunnerPrivateSrcBucket", { value: srcCodeBucket.bucketName })
         }
     }
 

--- a/netbench-cdk/lib/netbench.ts
+++ b/netbench-cdk/lib/netbench.ts
@@ -47,17 +47,20 @@ export class NetbenchInfra extends cdk.Stack {
             placementGroupName: 'NetbenchRunnerPlacementGroupCluster',
             strategy: ec2.PlacementGroupStrategy.CLUSTER
         });
+        new cdk.CfnOutput(this, "output:NetbenchRunnerPlacementGroupCluster", { value: cluster.placementGroupName})
         // Max 7 partitions per AZ: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html
         const partition = new ec2.PlacementGroup(this, 'Partition', {
             placementGroupName: 'NetbenchRunnerPlacementGroupPartition',
             partitions: 7,
             strategy: ec2.PlacementGroupStrategy.PARTITION
         });
+        new cdk.CfnOutput(this, "output:NetbenchRunnerPlacementGroupPartition", { value: partition.placementGroupName})
         const spread = new ec2.PlacementGroup(this, 'Spread', {
             placementGroupName: 'NetbenchRunnerPlacementGroupSpread',
             spreadLevel: ec2.PlacementGroupSpreadLevel.RACK,
             strategy: ec2.PlacementGroupStrategy.SPREAD
         })
+        new cdk.CfnOutput(this, "output:NetbenchRunnerPlacementGroupSpread", { value: spread.placementGroupName})
     }
     private createVPC() {
         // Creating VPC for clients and servers


### PR DESCRIPTION
### Resolved issues:

n/a

### Description of changes: 

Adds more values to the cdk output, as well as taking over managing an IAM user to be used by GitHub Actions.

### Call-outs:

We're letting CDK create the IAM policy for us, but we may need to take this over if the permission controls aren't granular enough. more testing required.

Earlier Placement groups are being removed in favor of letting the orchestration code handle it.

Current example cdk_output.json

```
{
  "NetbenchInfraPrimaryProd": {
    "outputNetbenchRunnerLogGroup": "NetbenchInfraPrimaryProd-NetbenchRunnerLogGroup2B821E01-yfykCkGeMuS4",
    "outputNetbenchCloudfrontDistribution": "https://d37mm99fcr6hy4.cloudfront.net",
    "outputNetbenchInfraPrimaryProdRegion": "us-west-2",
    "outputNetbenchRunnerPrivateSrcBucket": "netbenchrunner-private-source-prod",
    "outputNetbenchRunnerPublicLogsBucket": "netbenchrunnerlogs-public-prod",
    "outputNetbenchSubnetTagValue": "public-subnet-for-netbench-runners",
    "outputNetbenchSubnetTagKey": "aws-cdk:netbench-subnet-name",
    "outputNetbenchRunnerInstanceProfile": "NetbenchInfraPrimaryProd-instanceProfile9C1E1CDD-kVoSXbmUxoBA"
  }
}
```


### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? locally

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

