### PR TITLE
feat(orchestrator): base orchestrator components and s3 utils

### DIFF
--- a/netbench-orchestrator/Cargo.toml
+++ b/netbench-orchestrator/Cargo.toml
@@ -9,21 +9,26 @@ rust-version = "1.75"
 license = "Apache-2.0"
 
 [[bin]]
+name = "s2n-netbench-orchestrator"
+path = "src/main.rs"
+
+[[bin]]
 name = "russula_cli"
 path = "src/russula_cli.rs"
 
 [dependencies]
-tokio = { version = "1", features = ["full"] }
+aws-sdk-s3 = "1"
 bytes = "1"
-uuid = { version = "1", features = ["v4"] }
+humantime = "2"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
+structopt = { version = "0.3", default-features = false }
+sysinfo = "0.29"
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
-structopt = { version = "0.3", default-features = false }
-humantime = "2"
-sysinfo = "0.29"
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 futures = "0.3"

--- a/netbench-orchestrator/src/main.rs
+++ b/netbench-orchestrator/src/main.rs
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO remove
+#![allow(dead_code)]
+
+use crate::orchestrator::OrchResult;
+
+mod orchestrator;
+mod s3_utils;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> OrchResult<()> {
+    Ok(())
+}

--- a/netbench-orchestrator/src/orchestrator.rs
+++ b/netbench-orchestrator/src/orchestrator.rs
@@ -1,0 +1,7 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+mod error;
+mod state;
+
+pub use error::{OrchError, OrchResult};

--- a/netbench-orchestrator/src/orchestrator/error.rs
+++ b/netbench-orchestrator/src/orchestrator/error.rs
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub type OrchResult<T, E = OrchError> = Result<T, E>;
+
+#[derive(Debug)]
+pub enum OrchError {
+    // Initialization error
+    Init { dbg: String },
+    // Ec2 sdk error
+    Ec2 { dbg: String },
+    // Iam sdk error
+    Iam { dbg: String },
+    // Ssm sdk error
+    Ssm { dbg: String },
+    // S3 sdk error
+    S3 { dbg: String },
+}
+
+impl std::fmt::Display for OrchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OrchError::Init { dbg } => write!(f, "{}", dbg),
+            OrchError::Ec2 { dbg } => write!(f, "{}", dbg),
+            OrchError::Iam { dbg } => write!(f, "{}", dbg),
+            OrchError::Ssm { dbg } => write!(f, "{}", dbg),
+            OrchError::S3 { dbg } => write!(f, "{}", dbg),
+        }
+    }
+}
+
+impl std::error::Error for OrchError {}

--- a/netbench-orchestrator/src/orchestrator/state.rs
+++ b/netbench-orchestrator/src/orchestrator/state.rs
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::time::Duration;
+
+pub const STATE: State = State {
+    version: "v1.0.0",
+
+    // netbench
+    netbench_repo: "https://github.com/aws/s2n-netbench.git",
+    netbench_branch: "main",
+    netbench_port: 4433,
+
+    // orchestrator
+    host_home_path: "/home/ec2-user",
+    workspace_dir: "./target/netbench",
+    shutdown_min: 120, // 1 hour
+    poll_delay_ssm: Duration::from_secs(10),
+
+    // russula
+    russula_repo: "https://github.com/toidiu/netbench_orchestrator.git",
+    russula_branch: "ak-main",
+    russula_port: 9000,
+    poll_delay_russula: Duration::from_secs(5),
+
+    // aws
+    ami_name: "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64",
+    // https://github.com/aws/s2n-netbench/issues/35
+    // set a key pair to access the ec2 hosts
+    ssh_key_name: None,
+};
+
+pub struct State {
+    pub version: &'static str,
+
+    // netbench
+    pub netbench_repo: &'static str,
+    pub netbench_branch: &'static str,
+    pub netbench_port: u16,
+
+    // orchestrator
+    pub host_home_path: &'static str,
+    pub workspace_dir: &'static str,
+    pub shutdown_min: u16,
+    pub poll_delay_ssm: Duration,
+
+    // russula
+    pub russula_repo: &'static str,
+    pub russula_branch: &'static str,
+    pub russula_port: u16,
+    pub poll_delay_russula: Duration,
+
+    // aws
+    pub ami_name: &'static str,
+    pub ssh_key_name: Option<&'static str>,
+}

--- a/netbench-orchestrator/src/s3_utils.rs
+++ b/netbench-orchestrator/src/s3_utils.rs
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::orchestrator::OrchError;
+use crate::OrchResult;
+use aws_sdk_s3 as s3;
+use aws_sdk_s3::operation::{get_object::GetObjectOutput, put_object::PutObjectOutput};
+use std::{fs::File, io::prelude::*, path::Path};
+
+pub async fn download_object_to_file<P: AsRef<Path>>(
+    client: &s3::Client,
+    bucket_name: &str,
+    key: &str,
+    path: P,
+) -> OrchResult<usize> {
+    let path = path.as_ref();
+    let mut file = File::create(path).map_err(|err| OrchError::Init {
+        dbg: format!("failed to create file {:?}, {err}", path),
+    })?;
+
+    let mut obj = download_object(client, bucket_name, key).await?;
+
+    // write to file
+    let mut total_size = 0;
+    while let Some(bytes) = obj.body.try_next().await.map_err(|err| OrchError::S3 {
+        dbg: err.to_string(),
+    })? {
+        total_size += file.write(&bytes).map_err(|err| OrchError::Init {
+            dbg: format!("failed to write to file {:?}, {err}", file),
+        })?;
+    }
+
+    Ok(total_size)
+}
+
+pub async fn upload_object(
+    client: &s3::Client,
+    bucket_name: &str,
+    body: s3::primitives::ByteStream,
+    key: &str,
+) -> OrchResult<PutObjectOutput> {
+    client
+        .put_object()
+        .bucket(bucket_name)
+        .key(key)
+        .content_type("text/html")
+        .body(body)
+        .send()
+        .await
+        .map_err(|err| OrchError::S3 {
+            dbg: err.to_string(),
+        })
+}
+
+async fn download_object(
+    client: &s3::Client,
+    bucket_name: &str,
+    key: &str,
+) -> OrchResult<GetObjectOutput> {
+    client
+        .get_object()
+        .bucket(bucket_name)
+        .key(key)
+        .send()
+        .await
+        .map_err(|err| OrchError::S3 {
+            dbg: err.to_string(),
+        })
+}


### PR DESCRIPTION
### Description of changes: 
This PR adds the `s2n-netbench-orchestrator` bin. It also adds the error and s3 utility module which will be used later by the orchestrator.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

