### PR TITLE
feat(orchestrator): dashboad and report utils

### DIFF
--- a/netbench-orchestrator/Cargo.toml
+++ b/netbench-orchestrator/Cargo.toml
@@ -26,6 +26,7 @@ aws-sdk-ssm = "1"
 bytes = "1"
 clap = { version = "4", features = ["derive"] }
 humantime = "2"
+indicatif = "0.17"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 structopt = { version = "0.3", default-features = false }
@@ -34,8 +35,8 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
+tempfile = "3"
 uuid = { version = "1", features = ["v4"] }
-indicatif = "0.17"
 
 [dev-dependencies]
 futures = "0.3"

--- a/netbench-orchestrator/src/ec2_utils.rs
+++ b/netbench-orchestrator/src/ec2_utils.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    ec2_utils::types::{InstanceDetail, PubIp},
+    ec2_utils::types::PubIp,
     orchestrator::{OrchError, OrchResult},
 };
 use aws_sdk_ec2::{error::SdkError, types::PlacementGroup};
@@ -14,7 +14,7 @@ mod launch_plan;
 mod networking;
 mod types;
 
-pub use types::{Az, PrivIp};
+pub use types::{Az, EndpointType, InstanceDetail, PrivIp};
 
 const MAX_RETRY_COUNT: usize = 25;
 const RETRY_BACKOFF: Duration = Duration::from_secs(5);

--- a/netbench-orchestrator/src/ec2_utils/types.rs
+++ b/netbench-orchestrator/src/ec2_utils/types.rs
@@ -59,6 +59,10 @@ impl InstanceDetail {
     pub fn host_ips(&self) -> &HostIps {
         &self.host_ips
     }
+
+    pub fn endpoint_type(&self) -> &EndpointType {
+        &self.endpoint_type
+    }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]

--- a/netbench-orchestrator/src/orchestrator.rs
+++ b/netbench-orchestrator/src/orchestrator.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod cli;
+mod dashboard;
 mod error;
+mod report;
 mod state;
 
 pub use cli::{Cli, HostConfig, OrchestratorConfig};

--- a/netbench-orchestrator/src/orchestrator/dashboard.rs
+++ b/netbench-orchestrator/src/orchestrator/dashboard.rs
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    ec2_utils::{EndpointType, InstanceDetail},
+    orchestrator::{OrchResult, OrchestratorConfig},
+    s3_utils::upload_object,
+};
+use aws_sdk_s3::primitives::ByteStream;
+use bytes::Bytes;
+use tracing::info;
+
+pub enum Step<'a> {
+    UploadIndex,
+    HostsRunning(&'a Vec<InstanceDetail>),
+}
+
+pub async fn update_dashboard(
+    step: Step<'_>,
+    s3_client: &aws_sdk_s3::Client,
+    unique_id: &str,
+    config: &OrchestratorConfig,
+    endpoint_type: EndpointType,
+) -> OrchResult<()> {
+    match step {
+        Step::UploadIndex => upload_index_html(s3_client, unique_id, config).await,
+        Step::HostsRunning(instances) => {
+            update_instance_running(s3_client, instances, unique_id, config, endpoint_type).await
+        }
+    }
+}
+
+async fn upload_index_html(
+    s3_client: &aws_sdk_s3::Client,
+    unique_id: &str,
+    config: &OrchestratorConfig,
+) -> OrchResult<()> {
+    let cf_url = config.cf_url(unique_id);
+    let status = format!("{}/index.html", cf_url);
+    let template_server_prefix = format!("{}/server-step-", cf_url);
+    let template_client_prefix = format!("{}/client-step-", cf_url);
+    let template_finished_prefix = format!("{}/finished-step-", cf_url);
+
+    let index_file = std::fs::read_to_string("index.html")
+        .expect("index.html not found")
+        .replace("template_unique_id", unique_id)
+        .replace("template_server_prefix", &template_server_prefix)
+        .replace("template_client_prefix", &template_client_prefix)
+        .replace("template_finished_prefix", &template_finished_prefix);
+
+    // Upload to s3
+    upload_object(
+        s3_client,
+        config.cdk_config.netbench_runner_public_s3_bucket(),
+        ByteStream::from(Bytes::from(index_file)),
+        &format!("{unique_id}/index.html"),
+    )
+    .await?;
+
+    println!("Status: URL: {status}");
+    info!("Status: URL: {status}");
+
+    Ok(())
+}
+
+async fn update_instance_running(
+    s3_client: &aws_sdk_s3::Client,
+    instances: &[InstanceDetail],
+    unique_id: &str,
+    config: &OrchestratorConfig,
+    endpoint_type: EndpointType,
+) -> OrchResult<()> {
+    let instance_detail = instances
+        .iter()
+        .map(|instance| format!("{} {}", instance.host_ips(), instance.instance_id()))
+        .collect::<Vec<String>>()
+        .join(" - ");
+
+    let payload = ByteStream::from(Bytes::from(format!(
+        "EC2 {:?} instances up: {}",
+        endpoint_type, instance_detail
+    )));
+    upload_object(
+        s3_client,
+        config.cdk_config.netbench_runner_public_s3_bucket(),
+        payload,
+        &format!(
+            "{unique_id}/{}-step-0",
+            endpoint_type.as_str().to_lowercase()
+        ),
+    )
+    .await?;
+    Ok(())
+}

--- a/netbench-orchestrator/src/orchestrator/report.rs
+++ b/netbench-orchestrator/src/orchestrator/report.rs
@@ -1,0 +1,155 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{ec2_utils::InfraDetail, orchestrator::OrchestratorConfig, s3_utils, OrchResult};
+use aws_sdk_s3::primitives::{ByteStream, SdkBody};
+use std::{path::Path, process::Command};
+use tracing::{debug, info, trace};
+
+pub async fn orch_generate_report(
+    s3_client: &aws_sdk_s3::Client,
+    unique_id: &str,
+    infra: &InfraDetail,
+    config: &OrchestratorConfig,
+) -> OrchResult<()> {
+    let tmp_dir = tempfile::Builder::new()
+        .prefix(unique_id)
+        .tempdir()
+        .expect("failed to create temp dir")
+        .into_path();
+    let tmp_dir = tmp_dir.to_str().expect("failed to create temp dir");
+
+    download_results(unique_id, config, tmp_dir).await?;
+    generate_report_from_results(tmp_dir).await?;
+    upload_report_to_s3(unique_id, config, tmp_dir).await?;
+    update_report_url(s3_client, unique_id, config).await?;
+
+    println!("Report Finished!: Successful: true");
+    println!("URL: {}/report/index.html", config.cf_url(unique_id));
+    info!("Report Finished!: Successful: true");
+    info!("URL: {}/report/index.html", config.cf_url(unique_id));
+
+    download_remote_logs(unique_id, infra);
+
+    Ok(())
+}
+
+async fn upload_report_to_s3(
+    unique_id: &str,
+    config: &OrchestratorConfig,
+    tmp_dir: &str,
+) -> OrchResult<()> {
+    let mut cmd = Command::new("aws");
+    let output = cmd
+        .args([
+            "s3",
+            "sync",
+            tmp_dir,
+            &format!(
+                "s3://{}/{}",
+                config.cdk_config.netbench_runner_public_s3_bucket(),
+                unique_id
+            ),
+        ])
+        .output()
+        .unwrap();
+
+    debug!("{:?}", cmd);
+    trace!("{:?}", output);
+    assert!(cmd.status().expect("aws sync").success(), "aws sync");
+    Ok(())
+}
+
+async fn generate_report_from_results(tmp_dir: &str) -> OrchResult<()> {
+    let results_path = format!("{}/results", tmp_dir);
+    let report_path = format!("{}/report", tmp_dir);
+    let mut cmd = Command::new("s2n-netbench");
+    cmd.args(["report-tree", &results_path, &report_path]);
+    debug!("{:?}", cmd);
+    let status = cmd.status().expect("s2n-netbench command failed");
+    assert!(status.success(), " s2n-netbench command failed");
+
+    Ok(())
+}
+
+async fn download_results(
+    unique_id: &str,
+    config: &OrchestratorConfig,
+    tmp_dir: &str,
+) -> OrchResult<()> {
+    let mut cmd = Command::new("aws");
+    let output = cmd
+        .args([
+            "s3",
+            "sync",
+            &format!(
+                "s3://{}/{}",
+                config.cdk_config.netbench_runner_public_s3_bucket(),
+                unique_id
+            ),
+            tmp_dir,
+        ])
+        .output()
+        .unwrap();
+    debug!("{:?}", cmd);
+    trace!("{:?}", output);
+    assert!(cmd.status().expect("aws sync").success(), "aws sync");
+
+    Ok(())
+}
+
+async fn update_report_url(
+    s3_client: &aws_sdk_s3::Client,
+    unique_id: &str,
+    config: &OrchestratorConfig,
+) -> OrchResult<()> {
+    let body = ByteStream::new(SdkBody::from(format!(
+        "<a href=\"{}/report/index.html\">Final Report</a>",
+        config.cf_url(unique_id)
+    )));
+    let key = format!("{}/finished-step-0", unique_id);
+    s3_utils::upload_object(
+        s3_client,
+        config.cdk_config.netbench_runner_public_s3_bucket(),
+        body,
+        &key,
+    )
+    .await?;
+    Ok(())
+}
+
+// This function is best effort and will not return an error.
+//
+// Requires ssh access to the host. See STATE.ssh_key_name for more info
+fn download_remote_logs(unique_id: &str, infra: &InfraDetail) {
+    // get logs
+    let get_logs = true;
+    if get_logs {
+        infra.public_client_ips().iter().for_each(|ip| {
+            let log_folder = format!("./target/logs/{unique_id}/client_{ip}");
+            std::fs::create_dir_all(Path::new(&log_folder)).expect("create log dir");
+            let res = Command::new("scp")
+                .args([
+                    "-oStrictHostKeyChecking=no",
+                    &format!("ec2-user@{ip}:netbench_orchestrator/target/russula*"),
+                    &log_folder,
+                ])
+                .output();
+            debug!("client log download succeeded: {:?}", res.ok());
+        });
+
+        infra.public_server_ips().iter().for_each(|ip| {
+            let log_folder = format!("./target/logs/{unique_id}/server_{ip}");
+            std::fs::create_dir_all(Path::new(&log_folder)).expect("create log dir");
+            let res = Command::new("scp")
+                .args([
+                    "-oStrictHostKeyChecking=no",
+                    &format!("ec2-user@{ip}:netbench_orchestrator/target/russula*"),
+                    &log_folder,
+                ])
+                .output();
+
+            debug!("server log download succeeded: {:?}", res.ok());
+        });
+    }
+}

--- a/netbench-orchestrator/src/orchestrator/state.rs
+++ b/netbench-orchestrator/src/orchestrator/state.rs
@@ -25,8 +25,11 @@ pub const STATE: State = State {
 
     // aws
     ami_name: "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64",
+
+    // Configure hosts with an ec2 key pair to enable ssh access.
+    //
     // https://github.com/aws/s2n-netbench/issues/35
-    // set a key pair to access the ec2 hosts
+    // TODO take as input from user
     ssh_key_name: None,
 };
 


### PR DESCRIPTION
### Description of changes: 
This PR adds utility methods for the orchestrator dashboard(this is the url generated for each run) and netbench report (we download the data, generate the report locally and finally upload it to s3). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

