### PR TITLE
feat(orchestrator): init Russula framework

### DIFF
--- a/netbench-orchestrator/Cargo.toml
+++ b/netbench-orchestrator/Cargo.toml
@@ -13,9 +13,8 @@ name = "russula_cli"
 path = "src/russula_cli.rs"
 
 [dependencies]
-tokio = { version = "1.26.0", features = ["full"] }
-bytes = "1.4.0"
+tokio = { version = "1", features = ["full"] }
+bytes = "1"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
-tracing = "0.1.40"
-paste = "1.0.14"
+tracing = "0.1"

--- a/netbench-orchestrator/Cargo.toml
+++ b/netbench-orchestrator/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "s2n-netbench-orchestrator"
+version = "0.1.0"
+authors = ["AWS s2n"]
+description = "Utility to automate s2n-netbench runs"
+repository = "https://github.com/aws/s2n-netbench"
+edition = "2021"
+rust-version = "1.75"
+license = "Apache-2.0"
+
+[[bin]]
+name = "russula_cli"
+path = "src/russula_cli.rs"
+
+[dependencies]
+tokio = { version = "1.26.0", features = ["full"] }
+bytes = "1.4.0"
+serde = { version = "1", features = ["derive", "rc"] }
+serde_json = "1"
+tracing = "0.1.40"
+paste = "1.0.14"

--- a/netbench-orchestrator/README.md
+++ b/netbench-orchestrator/README.md
@@ -39,7 +39,7 @@ tasks such as installing/updating dependencies and uploading netbench data to s3
 also used to start the Russula worker process on each host. Russula is primarily used for
 timing sensitive tasks such netbench, which require starting and stopping multiple servers
 and clients processes across multiple hosts. Specifically, the 'Worker' component of a
-protocol is executed on the remote host, while the 'Coordinator' component is run locally
+workflow is executed on the remote host, while the 'Coordinator' component is run locally
 as part of the Orchestrator.
 
 ### Debugging
@@ -55,7 +55,7 @@ changed as desired.
 
 #### Remote
 **SSH access**
-ec2 accepts the name of a ssh-key when creating a new host. This is set to a default value
+ec2 accepts the name of an ssh-key when creating a new host. This is set to a default value
 under the value `ssh_key_name` in the [state.rs](/src/state.rs) file. By providing this key
 it is possible to ssh onto the remote host locally: `ssh -oStrictHostKeyChecking=no ec2-user@x.x.x.x`.
 Its also possible to ssh onto a host from the ec2 console on AWS.
@@ -95,10 +95,10 @@ a multi server/client netbench scenario.
 
 Since Russula is used to run Netbench testing it has the following goals:
 - non-blocking: its not acceptable to block since we are trying to do performance testing
-- minimal network noise: since we are trying to measure transport protocols, the coordination protocol
+- minimal network noise: since we are trying to measure transport protocols, the coordination workflow
 should add minimal traffic to the network
-- easily configurable: the protocol should allow for new states to allow for expanding use cases
-- secure: the protocol should not accept executable code since this opens it up for code execution attack.
+- easily configurable: the workflow should allow for new states to allow for expanding use cases
+- secure: the workflow should not accept executable code since this opens it up for code execution attack.
 - easy to develop: exposes logging and introspection into the peers states to allow for easy debugging
 - resilient: should be resilient to errors (network or otherwise); retrying requests when they are considered
 non-fatal

--- a/netbench-orchestrator/README.md
+++ b/netbench-orchestrator/README.md
@@ -1,0 +1,104 @@
+# Netbench Orchestrator
+
+Automate netbench runs in the cloud.
+
+## Goals
+Often developers of transport protocols are interested in gathering performance data for the protocol
+they are developing. Netbench is a tool which can be used to measure this performance data.
+However, its often necessary to run Netbench scenarios in the cloud so that the results better match
+production systems. The goal of this project is to automate Netbench runs in the cloud.
+
+## Getting started
+
+**Pre-requisites**
+- Built and include [netbench](https://github.com/aws/s2n-netbench) utilities (`cargo build`)
+  - Include in PATH `export PATH="s2n-netbench/target/release/:$PATH"`. Test with `which s2n-netbench`
+- AWS cli is installed. Test with `which aws`
+- An AWS account with some infrastructure configured. TODO: provide an easy way to do this
+  - Make sure AWS credentials are included in your shell environment
+- The ec2 SSH key name is correctly set in state.rs (make this configurable)
+
+**Running**
+
+```
+git clone git@github.com:toidiu/netbench_orchestrator.git && cd netbench_orchestrator
+
+# Run the orchestrator
+make run_orchestrator
+```
+
+## Project Overview
+Since the goal of the Orchestrator is to run workloads on remote servers, its best to think
+of the project as two components; stuff that runs locally vs remotely.
+
+- The **Orchestrator** runs **locally**, and is responsible for spinning up servers, and
+configuring them to run netbench. The orchestrator creates Russula 'Coordinators' to
+coordinate the remote netbench runs (done over TCP connection).
+- **SSM** and **Russula** run **remotely** on the hosts. SSM is used primarily for async
+tasks such as installing/updating dependencies and uploading netbench data to s3. SSM is
+also used to start the Russula worker process on each host. Russula is primarily used for
+timing sensitive tasks such netbench, which require starting and stopping multiple servers
+and clients processes across multiple hosts. Specifically, the 'Worker' component of a
+protocol is executed on the remote host, while the 'Coordinator' component is run locally
+as part of the Orchestrator.
+
+### Debugging
+As discussed in the above overview, there are processes that run locally and those that run
+remotely. This sections describes how to go about debugging each component.
+
+#### Local
+**Orchestrator**
+The Orchestrator is Rust code and ships with [tracing](https://docs.rs/tracing/latest/tracing/)
+support. Logs are written to a file `orch_proj/target/russula.log*` file on the host. The
+`make run_orchestrator` command enables sane log levels via `RUST_LOG=...` but these can be
+changed as desired.
+
+#### Remote
+**SSH access**
+ec2 accepts the name of a ssh-key when creating a new host. This is set to a default value
+under the value `ssh_key_name` in the [state.rs](/src/state.rs) file. By providing this key
+it is possible to ssh onto the remote host locally: `ssh -oStrictHostKeyChecking=no ec2-user@x.x.x.x`.
+Its also possible to ssh onto a host from the ec2 console on AWS.
+
+Useful command for debugging progress on remote host:
+```
+watch -n 1 "ls -xm; echo ===; ls -xm bin; echo ===; tail netbench_orchestrator/target/russula.log*; echo ===; ps aux | grep 'cargo\|russula\|netbench\|rustup';"
+```
+
+**Russula**
+The Worker component of Russula executes on the remote hosts. Russula is Rust code and also
+ships with [tracing](https://docs.rs/tracing/latest/tracing/) support. Logs are
+written to a file `orch_proj/target/russula.log*` file on the host. It can be quite useful
+to disable host cleanup when trying to debug issues on the remote hosts. See the SSH access
+section for how to access remote hosts.
+
+**SSM**
+SSM executes on the remote host and takes bash commands, which are executed by a 'ssm-agent'
+running on the remote host. It's important to note that by default SSM operations are run as
+the `root` user. Cloudwatch logging has been enabled for SSM and captures the 'stdout' and
+'stderr' output from execution. SSM commands are categorized into[Steps](src/ssm_utils.rs#L22)
+and each step emits a `start_step` file on the host when it begins and replaces it with
+`fin_step` when it finishes. These files are actually essential to making SSM execution
+serialized, but they also help with debugging. SSM failures can be quite painful to debug since
+failures can happen silently. See the SSH access section for how to access remote hosts.
+
+## Implementation details
+
+### Russula
+Russula is a coordination framework where a single Coordinator can be used to drive
+multiple Workers. This is driven by the need to test multiple server/client incast Netbench
+scenario.
+
+At its basis an instance of Russula is composed of a pair of Coordinator/Worker Protocols. Currently
+its possible to create an instance of NetbenchServer and NetbenchClient, which can be used to run
+a multi server/client netbench scenario.
+
+Since Russula is used to run Netbench testing it has the following goals:
+- non-blocking: its not acceptable to block since we are trying to do performance testing
+- minimal network noise: since we are trying to measure transport protocols, the coordination protocol
+should add minimal traffic to the network
+- easily configurable: the protocol should allow for new states to allow for expanding use cases
+- secure: the protocol should not accept executable code since this opens it up for code execution attack.
+- easy to develop: exposes logging and introspection into the peers states to allow for easy debugging
+- resilient: should be resilient to errors (network or otherwise); retrying requests when they are considered
+non-fatal

--- a/netbench-orchestrator/README.md
+++ b/netbench-orchestrator/README.md
@@ -44,7 +44,7 @@ as part of the Orchestrator.
 
 ### Debugging
 As discussed in the above overview, there are processes that run locally and those that run
-remotely. This sections describes how to go about debugging each component.
+remotely. This section describes how to go about debugging each component.
 
 #### Local
 **Orchestrator**

--- a/netbench-orchestrator/README.md
+++ b/netbench-orchestrator/README.md
@@ -85,17 +85,17 @@ failures can happen silently. See the SSH access section for how to access remot
 ## Implementation details
 
 ### Russula
-Russula is a coordination framework where a single Coordinator can be used to drive
+Russula is a workflow framework where a single Coordinator can be used to drive
 multiple Workers. This is driven by the need to test multiple server/client incast Netbench
 scenario.
 
-At its basis an instance of Russula is composed of a pair of Coordinator/Worker Protocols. Currently
+At its basis an instance of Workflow is composed of a pair of Coordinator/Worker workflows. Currently
 its possible to create an instance of NetbenchServer and NetbenchClient, which can be used to run
 a multi server/client netbench scenario.
 
 Since Russula is used to run Netbench testing it has the following goals:
 - non-blocking: its not acceptable to block since we are trying to do performance testing
-- minimal network noise: since we are trying to measure transport protocols, the coordination workflow
+- minimal network noise: since we are trying to measure transport protocols, the workflow
 should add minimal traffic to the network
 - easily configurable: the workflow should allow for new states to allow for expanding use cases
 - secure: the workflow should not accept executable code since this opens it up for code execution attack.

--- a/netbench-orchestrator/src/russula/error.rs
+++ b/netbench-orchestrator/src/russula/error.rs
@@ -1,0 +1,68 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use tokio::io::ErrorKind;
+
+pub type RussulaResult<T, E = RussulaError> = Result<T, E>;
+
+/// Custom error type emitted by Russula.
+#[derive(Debug)]
+pub enum RussulaError {
+    /// The remote server refused the connection.
+    NetworkConnectionRefused { dbg: String },
+
+    /// A non-recoverable network error.
+    NetworkFail { dbg: String },
+
+    /// A read from the socket returned an error.
+    ReadFail { dbg: String },
+
+    /// Possibly no more data to read. Try again later.
+    NetworkBlocked { dbg: String },
+
+    /// Failure when trying to read a [Msg](crate::russula::network_utils::Msg)
+    BadMsg { dbg: String },
+}
+
+impl std::fmt::Display for RussulaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RussulaError::NetworkConnectionRefused { dbg } => {
+                write!(f, "NetworkConnectionRefused {}", dbg)
+            }
+            RussulaError::NetworkFail { dbg } => write!(f, "NetworkFail {}", dbg),
+            RussulaError::ReadFail { dbg } => write!(f, "ReadFail {}", dbg),
+            RussulaError::NetworkBlocked { dbg } => write!(f, "NetworkBlocked {}", dbg),
+            RussulaError::BadMsg { dbg } => write!(f, "BadMsg {}", dbg),
+        }
+    }
+}
+
+impl std::error::Error for RussulaError {}
+
+impl RussulaError {
+    /// Specify which errors are non-recoverable.
+    #[allow(clippy::match_like_matches_macro)]
+    pub fn is_fatal(&self) -> bool {
+        match self {
+            RussulaError::NetworkBlocked { dbg: _ } => false,
+            _ => true,
+        }
+    }
+}
+
+impl From<tokio::io::Error> for RussulaError {
+    fn from(err: tokio::io::Error) -> Self {
+        match err.kind() {
+            ErrorKind::WouldBlock => RussulaError::NetworkBlocked {
+                dbg: err.to_string(),
+            },
+            ErrorKind::ConnectionRefused => RussulaError::NetworkConnectionRefused {
+                dbg: err.to_string(),
+            },
+            _ => RussulaError::NetworkFail {
+                dbg: err.to_string(),
+            },
+        }
+    }
+}

--- a/netbench-orchestrator/src/russula/error.rs
+++ b/netbench-orchestrator/src/russula/error.rs
@@ -42,11 +42,14 @@ impl std::error::Error for RussulaError {}
 
 impl RussulaError {
     /// Specify which errors are non-recoverable.
-    #[allow(clippy::match_like_matches_macro)]
     pub fn is_fatal(&self) -> bool {
         match self {
+            RussulaError::NetworkConnectionRefused { dbg: _ }
+            | RussulaError::NetworkFail { dbg: _ }
+            | RussulaError::ReadFail { dbg: _ }
+            | RussulaError::BadMsg { dbg: _ } => true,
+            // read/write operation would blocked and should be tried later
             RussulaError::NetworkBlocked { dbg: _ } => false,
-            _ => true,
         }
     }
 }

--- a/netbench-orchestrator/src/russula/event.rs
+++ b/netbench-orchestrator/src/russula/event.rs
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::fmt::{Debug, Display};
+
+/// A list of events emitted by Russula.
+pub enum EventType {
+    /// A Msg was sent.
+    SendMsg,
+
+    /// A Msg was received.
+    RecvMsg,
+}
+
+/// An event recorder for Russula.
+#[derive(Debug, Default, Clone)]
+pub struct EventRecorder {
+    send_msg: u64,
+    recv_msg: u64,
+}
+
+impl EventRecorder {
+    pub fn process(&mut self, event: EventType) {
+        match event {
+            EventType::SendMsg => self.send_msg += 1,
+            EventType::RecvMsg => self.recv_msg += 1,
+        }
+    }
+}
+
+impl Display for EventRecorder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "send_cnt: {}, recv_cnt: {}",
+            self.send_msg, self.recv_msg
+        )
+    }
+}

--- a/netbench-orchestrator/src/russula/event.rs
+++ b/netbench-orchestrator/src/russula/event.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use core::fmt::{Debug, Display};
+use core::fmt::Debug;
 
 /// A list of events emitted by Russula.
 pub enum EventType {
@@ -25,15 +25,5 @@ impl EventRecorder {
             EventType::SendMsg => self.send_msg += 1,
             EventType::RecvMsg => self.recv_msg += 1,
         }
-    }
-}
-
-impl Display for EventRecorder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "send_cnt: {}, recv_cnt: {}",
-            self.send_msg, self.recv_msg
-        )
     }
 }

--- a/netbench-orchestrator/src/russula/mod.rs
+++ b/netbench-orchestrator/src/russula/mod.rs
@@ -1,0 +1,177 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::{task::Poll, time::Duration};
+use paste::paste;
+use std::{collections::BTreeSet, net::SocketAddr};
+use tokio::net::TcpStream;
+use tracing::{error, info};
+
+mod error;
+mod event;
+mod network_utils;
+mod protocol;
+mod states;
+
+use error::{RussulaError, RussulaResult};
+use protocol::Protocol;
+
+struct ProtocolInstance<P: Protocol> {
+    pub addr: SocketAddr,
+    pub stream: TcpStream,
+    pub protocol: P,
+}
+
+/// A coordination framework.
+///
+/// Russula is a wrapper over a pair of Coordinator and Worker [Protocol]s.
+/// A Coordinator can be used to synchronize multiple workers across
+/// different hosts.
+pub struct Russula<P: Protocol> {
+    /// List of protocol instance to synchronize with.
+    instance_list: Vec<ProtocolInstance<P>>,
+
+    /// Polling frequency when trying to make progress.
+    poll_delay: Duration,
+}
+
+macro_rules! state_api {
+    {
+        $(#[$meta:meta])*
+            $state:ident
+    } => {paste!{
+
+    $(#[$meta])*
+    pub async fn [<run_till_ $state>](&mut self) -> RussulaResult<()> {
+        while self.[<poll_ $state>]().await?.is_pending() {
+            tokio::time::sleep(self.poll_delay).await;
+        }
+
+        Ok(())
+    }
+
+    $(#[$meta])*
+    pub async fn [<poll_ $state>](&mut self) -> RussulaResult<Poll<()>> {
+        // Poll each peer protocol instance.
+        //
+        // If the peer is already in the desired state then this should be a noop.
+        for peer in self.instance_list.iter_mut() {
+            if let Err(err) = peer.protocol.[<poll_ $state>](&mut peer.stream).await {
+                if err.is_fatal() {
+                    error!("{} {}", err, peer.addr);
+                    panic!("{} {}", err, peer.addr);
+                }
+            }
+        }
+
+        // Check that all instances are at the desired state.
+        let poll = if self.[<is_ $state _state>]() {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        };
+        Ok(poll)
+    }
+
+    /// Check if all instances are at the desired state
+    fn [< is_ $state _state>](&self) -> bool {
+        for peer in self.instance_list.iter() {
+            // All instance must be at the desired state
+            if !peer.protocol.[< is_ $state _state>]() {
+                return false;
+            }
+        }
+        true
+    }
+}};
+}
+
+impl<P: Protocol + Send> Russula<P> {
+    state_api!(
+        /// Successfully connected to peer instances and ready to make progress.
+        ready
+    );
+    state_api!(
+        /// The coordination completed and reached a terminal state.
+        done
+    );
+    state_api!(
+        /// Note: Should only be called by Coordinators
+        ///
+        /// A intermediate state to query if Worker peers are in some
+        /// desired state.
+        worker_running
+    );
+}
+
+type SockProtocol<P> = (SocketAddr, P);
+pub struct RussulaBuilder<P: Protocol> {
+    /// Address on which the Coordinator and Worker communicate on.
+    ///
+    /// The Coordinator gets a list of workers addrs to 'connect' to. This can
+    /// be of size >= 1. The Worker gets its own addr to 'listen' on and should
+    /// be size = 1.
+    // TODO Create different Russula struct for Coordinator/Workers to capture
+    // different usage patterns.
+    protocol_addr_pair_list: Vec<SockProtocol<P>>,
+    poll_delay: Duration,
+}
+
+impl<P: Protocol> RussulaBuilder<P> {
+    pub fn new(peer_addr: BTreeSet<SocketAddr>, protocol: P, poll_delay: Duration) -> Self {
+        // TODO if worker check that the list is len 1 and points to local addr on which to listen
+        let mut peer_list = Vec::new();
+        peer_addr.into_iter().for_each(|addr| {
+            peer_list.push((addr, protocol.clone()));
+        });
+        Self {
+            protocol_addr_pair_list: peer_list,
+            poll_delay,
+        }
+    }
+
+    pub async fn build(self) -> RussulaResult<Russula<P>> {
+        let mut stream_protocol_list = Vec::new();
+        for (addr, protocol) in self.protocol_addr_pair_list.into_iter() {
+            let mut retry_attempts = 10;
+            loop {
+                if retry_attempts == 0 {
+                    return Err(RussulaError::NetworkConnectionRefused {
+                        dbg: "Failed to connect to peer".to_string(),
+                    });
+                }
+                match protocol.pair_peer(&addr).await {
+                    Ok(connect) => {
+                        info!("Coordinator: successfully connected to {}", addr);
+                        stream_protocol_list.push(ProtocolInstance {
+                            addr,
+                            stream: connect,
+                            protocol,
+                        });
+
+                        break;
+                    }
+                    Err(err) => {
+                        error!(
+                            "Failed to connect.. wait and retry. Try disabling VPN and check your network connectivity.
+                            \nRetry attempts left: {}. addr: {} dbg: {}",
+                            retry_attempts, addr, err
+                        );
+                        println!(
+                            "Failed to connect.. wait and retry. Try disabling VPN and check your network connectivity.
+                            \nRetry attempts left: {}. addr: {} dbg: {}",
+                            retry_attempts, addr, err
+                        );
+                        tokio::time::sleep(self.poll_delay).await;
+                    }
+                }
+                retry_attempts -= 1
+            }
+        }
+
+        Ok(Russula {
+            instance_list: stream_protocol_list,
+            poll_delay: self.poll_delay,
+        })
+    }
+}

--- a/netbench-orchestrator/src/russula/mod.rs
+++ b/netbench-orchestrator/src/russula/mod.rs
@@ -15,7 +15,7 @@ mod workflow;
 use error::{RussulaError, RussulaResult};
 use workflow::WorkflowTrait;
 
-const CONNENT_RETRY_ATTEMPT: usize = 10;
+const CONNECT_RETRY_ATTEMPT: usize = 10;
 
 #[derive(Debug, Copy, Clone)]
 pub enum WorkflowState {
@@ -28,7 +28,7 @@ pub enum WorkflowState {
 
     /// Indicates that worker are running and accepting work.
     ///
-    /// For netbench this state be used to confirm that all servers are
+    /// For netbench this state can be used to confirm that all servers are
     /// running and accepting connection before starting netbench clients.
     /// Should only be called by Coordinators.
     WorkerRunning,
@@ -131,7 +131,7 @@ impl<W: WorkflowTrait> WorkflowBuilder<W> {
     pub async fn build(self) -> RussulaResult<Workflow<W>> {
         let mut workflow_instances = Vec::new();
         for (addr, workflow) in self.addrs.into_iter() {
-            let mut retry_attempts = CONNENT_RETRY_ATTEMPT;
+            let mut retry_attempts = CONNECT_RETRY_ATTEMPT;
             loop {
                 if retry_attempts == 0 {
                     return Err(RussulaError::NetworkConnectionRefused {

--- a/netbench-orchestrator/src/russula/network_utils.rs
+++ b/netbench-orchestrator/src/russula/network_utils.rs
@@ -1,0 +1,130 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::russula::{RussulaError, RussulaResult};
+use bytes::Bytes;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
+use tracing::error;
+
+// Msg.len is represented as a u16
+const LEN_PREFIX_BYTES: usize = 2;
+
+/// Data format for messages exchanged with a peer.
+#[derive(Debug)]
+pub struct Msg {
+    /// Specifies the number of bytes of data.
+    len: u16,
+
+    /// Payload represented a Bytes.
+    data: Bytes,
+}
+
+/// Receive a Msg from the peer.
+pub async fn recv_msg(stream: &mut TcpStream) -> RussulaResult<Msg> {
+    stream.readable().await.map_err(log_fatal_error)?;
+    read_msg(stream).await
+}
+
+/// Send a Msg to the peer.
+pub async fn send_msg(stream: &mut TcpStream, msg: Msg) -> RussulaResult<usize> {
+    stream.writable().await.map_err(log_fatal_error)?;
+    write_msg(stream, msg).await
+}
+
+async fn read_msg(stream: &mut TcpStream) -> RussulaResult<Msg> {
+    let mut len_buf = [0; LEN_PREFIX_BYTES];
+    let bytes_read = stream.read_exact(&mut len_buf).await?;
+    let expected_payload_len = match bytes_read {
+        LEN_PREFIX_BYTES => u16::from_be_bytes(len_buf) as usize,
+        _ => {
+            let dbg = "read returned 0 bytes.. read closed?".to_string();
+            error!(dbg);
+            return Err(RussulaError::ReadFail { dbg });
+        }
+    };
+
+    let mut data = vec![0; expected_payload_len];
+    let bytes_read = stream
+        .read_exact(&mut data)
+        .await
+        .map_err(log_fatal_error)?;
+
+    match bytes_read {
+        bytes_read if bytes_read == expected_payload_len => Msg::new(data.into()),
+        bytes_read => {
+            let received_data =
+                std::str::from_utf8(&data).unwrap_or("Unable to parse bytes as str!!");
+            let dbg = format!(
+                "read len: {} but expected_len: {}. data: {}",
+                bytes_read, expected_payload_len, received_data
+            );
+            error!(dbg);
+            Err(RussulaError::ReadFail { dbg })
+        }
+    }
+}
+
+async fn write_msg(stream: &mut TcpStream, msg: Msg) -> RussulaResult<usize> {
+    let data = construct_payload(msg);
+    stream.write_all(&data).await?;
+    stream.flush().await?;
+    Ok(data.len())
+}
+
+fn construct_payload(msg: Msg) -> Vec<u8> {
+    // size of len prefix + size of msg.data
+    let payload_len = LEN_PREFIX_BYTES + msg.len as usize;
+    let mut data: Vec<u8> = Vec::with_capacity(payload_len);
+    data.extend(msg.len.to_be_bytes());
+    data.extend(msg.data);
+    data
+}
+
+fn log_fatal_error(err: tokio::io::Error) -> RussulaError {
+    let russula_err = RussulaError::from(err);
+    match &russula_err {
+        error if error.is_fatal() => tracing::error!("{}", error),
+        _ => (),
+    }
+    russula_err
+}
+
+impl Msg {
+    pub fn new(data: Bytes) -> RussulaResult<Msg> {
+        let _ = std::str::from_utf8(&data).map_err(|err| RussulaError::BadMsg {
+            dbg: format!(
+                "Failed to parse msg as utf8. len: {} data: {:?}, {err}",
+                data.len(),
+                data
+            ),
+        })?;
+
+        Ok(Msg {
+            len: data.len() as u16,
+            data,
+        })
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.data
+    }
+
+    pub fn as_str(&self) -> &str {
+        // unwrap is safe since we check that data is a valid utf8 slice when
+        // constructing a Msg struct
+        std::str::from_utf8(&self.data).unwrap()
+    }
+
+    pub fn payload_len(&self) -> u16 {
+        self.len
+    }
+}
+
+impl std::fmt::Display for Msg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let data = std::str::from_utf8(&self.data).expect("expected str");
+        write!(f, "Msg [ len: {} data: {} ]", self.len, data)
+    }
+}

--- a/netbench-orchestrator/src/russula/protocol.rs
+++ b/netbench-orchestrator/src/russula/protocol.rs
@@ -1,0 +1,252 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    error::RussulaError,
+    event::EventType,
+    network_utils,
+    network_utils::Msg,
+    states::{StateApi, TransitionStep},
+    RussulaResult,
+};
+use crate::russula::event::EventRecorder;
+use core::{task::Poll, time::Duration};
+use paste::paste;
+use std::net::SocketAddr;
+use tokio::net::TcpStream;
+use tracing::{debug, info};
+
+// Send the Done status multiple times to the peer incase there is packet loss.
+const NOTIFY_DONE_TIMEOUT: Duration = Duration::from_secs(1);
+
+macro_rules! state_api {
+{
+    $(#[$meta:meta])*
+    $state:ident
+} => {paste!{
+
+    $(#[$meta])*
+    fn [<$state _state>](&self) -> Self::State;
+
+    $(#[$meta])*
+    /// Check if the Instance is at the desired state
+    fn [<is_ $state _state>](&self) -> bool {
+        let state = self.[<$state _state>]();
+        self.state().eq(&state)
+    }
+
+    $(#[$meta])*
+    async fn [<poll_ $state>](&mut self, stream: &mut TcpStream) -> RussulaResult<Poll<()>> {
+        self.poll_state(stream, &self.[<$state _state>]()).await
+    }
+}};
+}
+
+macro_rules! notify_peer {
+{$protocol:ident, $stream:ident} => {
+    use crate::russula::network_utils;
+    let msg = Msg::new($protocol.state().as_bytes())
+        .expect("Msg data should be a valid string");
+    debug!(
+        "{} ----> send msg {}",
+        $protocol.name(),
+        &msg.as_str()
+    );
+    network_utils::send_msg($stream, msg).await?;
+    $protocol.on_event(EventType::SendMsg);
+}
+}
+pub(crate) use notify_peer;
+
+pub trait Protocol: Clone {
+    type State: StateApi;
+
+    /// Protocol specific pairing behavior.
+    ///
+    /// Coordinators should connect to Workers. Workers should accept connections
+    /// from Coordinators.
+    async fn pair_peer(&self, addr: &SocketAddr) -> RussulaResult<TcpStream>;
+
+    /// Run operations for the current state.
+    async fn run(&mut self, stream: &mut TcpStream) -> RussulaResult<Option<Msg>>;
+
+    /// Retrieve the current state.
+    fn state(&self) -> &Self::State;
+    fn state_mut(&mut self) -> &mut Self::State;
+
+    /// Track events for the current protocol.
+    fn event_recorder(&mut self) -> &mut EventRecorder;
+
+    /// Used for debugging and creating unique log files.
+    fn name(&self) -> String;
+
+    /// Track the peers state. Mainly used for debugging.
+    fn update_peer_state(&mut self, msg: Msg) -> RussulaResult<()>;
+
+    state_api!(ready);
+    state_api!(done);
+    state_api!(
+        /// Should only be called by Coordinators
+        worker_running
+    );
+
+    /// Run operations for the current state and attempt to make progress until
+    /// the desired state is reached.
+    async fn poll_state(
+        &mut self,
+        stream: &mut TcpStream,
+        desired_state: &Self::State,
+    ) -> RussulaResult<Poll<()>> {
+        if !self.state().eq(desired_state) {
+            let initial_state = self.state().as_bytes();
+            self.run_current(stream).await?;
+
+            debug!(
+                "{} poll_state--------{:?} -> {:?}",
+                self.name(),
+                initial_state,
+                self.state()
+            );
+        }
+
+        // Notify the peer that we have reached a terminal state
+        //
+        // The Done state is special and only notifies the peer of our Done status.
+        if self.is_done_state() {
+            tracing::info!("{}", self.event_recorder());
+
+            // Notify 3 time in case of packet loss.. this is best effort
+            for _i in 0..3 {
+                match self.run_current(stream).await {
+                    Ok(_) => (),
+                    // We notify the peer of the Done state multiple times. Since the peer could
+                    // have killed the connection in the meantime, its better to ignore network
+                    // failures
+                    Err(RussulaError::NetworkConnectionRefused { dbg: _ })
+                    | Err(RussulaError::NetworkBlocked { dbg: _ })
+                    | Err(RussulaError::NetworkFail { dbg: _ }) => {
+                        debug!("Ignore network failure since coordination is Done.")
+                    }
+                    Err(err) => return Err(err),
+                }
+                tokio::time::sleep(NOTIFY_DONE_TIMEOUT).await;
+            }
+        }
+
+        if self.state().eq(desired_state) {
+            Ok(Poll::Ready(()))
+        } else {
+            Ok(Poll::Pending)
+        }
+    }
+
+    /// Run operations for the current [Self::State]
+    async fn run_current(&mut self, stream: &mut TcpStream) -> RussulaResult<()> {
+        if let Some(msg) = self.run(stream).await? {
+            self.update_peer_state(msg)?;
+        }
+        Ok(())
+    }
+
+    /// Attempt to receive a [Msg] from the peer.
+    async fn await_next_msg(&mut self, stream: &mut TcpStream) -> RussulaResult<Option<Msg>> {
+        // Check to ensure correct usage
+        if !matches!(self.state().transition_step(), TransitionStep::AwaitNext(_)) {
+            panic!(
+                "should await_next_msg only if the transition_step is AwaitNext. Actual: {:?}",
+                self.state().transition_step()
+            );
+        }
+
+        // loop until we transition or drain all msg from queue.
+        //
+        // network_utils::recv_msg aborts if the read queue is empty.
+        // Continue to read from stream until:
+        // - the msg results in a transition
+        // - there is no more data available (drained all messages)
+        // - there is a error while reading
+        let mut last_msg = None;
+        loop {
+            match network_utils::recv_msg(stream).await {
+                Ok(msg) => {
+                    self.on_event(EventType::RecvMsg);
+                    debug!("{} <---- recv msg {}", self.name(), &msg.as_str());
+
+                    let should_transition = self.matches_transition_msg(&msg)?;
+                    last_msg = Some(msg);
+                    if should_transition {
+                        self.transition_next(stream).await?;
+                        break;
+                    }
+                }
+                Err(err) if !err.is_fatal() => {
+                    // notifying the peer here is an optimization since the protocol
+                    // should be polled externally and this operation retried.
+                    notify_peer!(self, stream);
+
+                    break;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        Ok(last_msg)
+    }
+
+    /// Check if a received [Msg] transitions self to the next state.
+    ///
+    /// The current transition_step should be [TransitionStep::AwaitNext].
+    fn matches_transition_msg(&self, recv_msg: &Msg) -> RussulaResult<bool> {
+        let state = self.state();
+        if let TransitionStep::AwaitNext(expected_msg) = state.transition_step() {
+            let should_transition_to_next = expected_msg == recv_msg.as_bytes();
+            debug!(
+                "{} expect: {} actual: {}",
+                self.name(),
+                std::str::from_utf8(&expected_msg)
+                    .expect("AwaitNext should contain valid string slices"),
+                recv_msg.as_str()
+            );
+            Ok(should_transition_to_next)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Transition to next state
+    async fn transition_next(&mut self, stream: &mut TcpStream) -> RussulaResult<()> {
+        let nxt = self.state().next_state();
+        info!(
+            "{:?} MOVING TO NEXT STATE. {:?} ===> {:?}",
+            self.name(),
+            self.state(),
+            nxt
+        );
+
+        *self.state_mut() = nxt;
+
+        // notify the peer of the new state
+        notify_peer!(self, stream);
+
+        Ok(())
+    }
+
+    /// Transition to next state triggered by a user input or self triggered event.
+    async fn transition_self_or_user_driven(
+        &mut self,
+        stream: &mut TcpStream,
+    ) -> RussulaResult<()> {
+        let state = self.state();
+        assert!(
+            matches!(state.transition_step(), TransitionStep::SelfDriven)
+                || matches!(state.transition_step(), TransitionStep::UserDriven)
+        );
+
+        self.transition_next(stream).await
+    }
+
+    /// Process an event.
+    fn on_event(&mut self, event: EventType) {
+        self.event_recorder().process(event);
+    }
+}

--- a/netbench-orchestrator/src/russula/states.rs
+++ b/netbench-orchestrator/src/russula/states.rs
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{error::RussulaError, network_utils::Msg};
+use crate::russula::RussulaResult;
+use bytes::Bytes;
+use core::fmt::Debug;
+use serde::{Deserialize, Serialize};
+
+/// Specify how a state machine might transition to the next State.
+///
+/// A state machine can move to the next state by receiving a message from
+/// its peer, a signal from the external user or be itself after after
+/// completing a task.
+#[derive(Debug)]
+pub enum TransitionStep {
+    /// The State machine should transition to the next state itself.
+    ///
+    /// Can be use to represent waiting for some long running task.
+    SelfDriven,
+
+    /// Wait for external user input before moving to the next state.
+    UserDriven,
+
+    /// Wait for a peer [Msg] before moving to the next state
+    AwaitNext(Bytes),
+
+    /// Used to signal the terminal state of a state machine.
+    Finished,
+}
+
+pub trait StateApi: Debug + Serialize + for<'a> Deserialize<'a> {
+    /// The [TransitionStep] required to move to the next state.
+    fn transition_step(&self) -> TransitionStep;
+
+    /// Returns the next step in the state machine.
+    fn next_state(&self) -> Self;
+
+    fn eq(&self, other: &Self) -> bool {
+        self.as_bytes() == other.as_bytes()
+    }
+
+    fn as_bytes(&self) -> Bytes {
+        serde_json::to_string(self).unwrap().into()
+    }
+
+    fn from_msg(msg: Msg) -> RussulaResult<Self> {
+        let msg_str = msg.as_str();
+        serde_json::from_str(msg_str).map_err(|_err| RussulaError::BadMsg {
+            dbg: format!(
+                "received a malformed msg. len: {} data: {:?}",
+                msg.payload_len(),
+                msg.as_str()
+            ),
+        })
+    }
+}

--- a/netbench-orchestrator/src/russula_cli.rs
+++ b/netbench-orchestrator/src/russula_cli.rs
@@ -1,0 +1,7 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[allow(dead_code)]
+mod russula;
+
+fn main() {}

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.74.0"
+channel = "1.75.0"
 components = [ "rustc", "clippy", "rustfmt" ]


### PR DESCRIPTION
https://github.com/aws/s2n-netbench/issues/21

### Suggestions on how to review this PR
One suggestion to help review this PR would be to read the entire PR description and Readme in the PR to gain an understanding of what Russula is and why we need it.

Following this it could be useful to understand how Russula will be used. Unfortunately, this is harder to decipher since that will be introduced in following PRs. See https://github.com/aws/s2n-netbench/issues/21 for a list of upcoming PRs. Instead one can look here [link](https://github.com/aws/s2n-netbench/blob/ak-fullOrchImport/netbench-orchestrator/src/orchestrator.rs#L180-L203) to see how it will finally be used in the orchestrator.

Reviewing files:
- mod.rs: the entry point which contains the builder and the russula::Endpoint. The endpoint will be entry point for application and exposes 2 public APIs.
- protocol.rs: the underlying mechanism for Russula. Protocol is a trait and impl of Protocol will be introduced in following PRs. The most important fn in Protocol is `poll_state_impl`, which essentially checks if we are the desired state, otherwise `run`s actions associated with the current state.
- state.rs: `trait Protocol` has an associated type Sate which is used to reason about state transitions. This file captures some common functionality associated with State.
- network_utils.rs: has usesful fn to send/recv messages between russula endpoints. The file also includes the struct Msg is composed of len and data (essentially [TLV](https://en.wikipedia.org/wiki/Type%E2%80%93length%E2%80%93value) encoding but minus the tag). Msg is used to read a single message at a time, in a serialized manner, from the socket since messages have side-effects depending on the current state and can also lead to state transitions.
- other files: should be pretty self explanatory

### Description
This PR creates the netbench-orchestrator project and introduces the Russula component.

**An overview of Russula**
Russula is component which will be used by netbench-orchestrator (coming in following PRs) to coordinate netbench servers and clients on remote hosts. Russula is composed of a pair of Coordinator/Worker instances. A single Russula Coordinator is used to coordinate and drive multiple Russula Workers.

**Why do we need to coordinate netbench clients and servers?**

To answer why we need to coordinate clients/server, lets look at what is involved when running netbench manually: 
- generate a netbench scenario file
- launch a netbench server (provide the scenario file)
- **wait** for netbench server to start running 
- launch a netbench client (provide the same scenario file) + (provide a list of server addresses)
- **wait** for the netbench client to finish (recv/send all data which can vary based on environment)
- manually stop the netbench server
- generate a netbench report

The difficulty when trying to automate the above steps is to account for the **wait**s. Wait too little and the netbench run will fail. Run too long (but how long?) and the report will include alot of uninteresting data (potentially making the report difficult to parse). Throw in the variability of network delays/loss, variability of the cloud, running multiple netbench drivers in a single run, and running incase scenarios with multiple servers/clients; its easy to see that naively waiting is not the correct solution. In fact earlier iterations of the project validated that waiting naively is not the correct solution.

**Coordinating** the servers/clients essentially means that some process has direct visibility into how long we should wait and can execute the next step as soon as the previous step has completed.

### Call-outs:
This simply introduces the Russula framework. Following PRs introduce netbench specific Russula protocols, which are used to test the protocol.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

