### PR TITLE
chore: s2n-tls version bump

### DIFF
--- a/.github/config/cargo-deny.toml
+++ b/.github/config/cargo-deny.toml
@@ -32,6 +32,7 @@ allow = [
     "ISC",
     "MIT",
     "OpenSSL",
+    "Unicode-3.0",
     "Unicode-DFS-2016",
     "Zlib",
 ]

--- a/netbench-driver-s2n-tls/Cargo.toml
+++ b/netbench-driver-s2n-tls/Cargo.toml
@@ -12,8 +12,8 @@ license = "Apache-2.0"
 clap = { version = "4", features = ["derive"] }
 netbench = { version = "0.1", path = "../netbench", package = "s2n-netbench" }
 netbench-driver = { version = "0.1", path = "../netbench-driver", package = "s2n-netbench-driver" }
-s2n-tls = { version = "=0.0.39" }
-s2n-tls-tokio = { version = "=0.0.39" }
+s2n-tls = { version = "=0.2.7" }
+s2n-tls-tokio = { version = "=0.2.7" }
 tokio = { version = "1", features = ["io-util", "net", "time", "rt-multi-thread"] }
 
 [[bin]]


### PR DESCRIPTION
### Resolved issues:

n/a

### Description of changes: 

Addressing https://github.com/aws/s2n-tls/security/advisories/GHSA-52xf-5p2m-9wrv

### Call outs

Updated the allowed license for unicode.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

